### PR TITLE
feat: finishing final prize distribution and game reset logic in make…

### DIFF
--- a/programs/blockrunners/src/errors.rs
+++ b/programs/blockrunners/src/errors.rs
@@ -23,6 +23,9 @@ pub enum BlockrunnersError {
     #[msg("Player has already completed the path")]
     PathAlreadyCompleted,
 
+    #[msg("Arithmetic overflow occurred during calculation")]
+    ArithmeticOverflow,
+
     #[msg("Unknown Error")]
     UnknownError,
 }

--- a/programs/blockrunners/src/instructions/initialize_game.rs
+++ b/programs/blockrunners/src/instructions/initialize_game.rs
@@ -25,9 +25,13 @@ pub struct InitializeGame<'info> {
 pub fn initialize_game(ctx: Context<InitializeGame>) -> Result<()> {
     let game_state = &mut ctx.accounts.game_state;
 
+    // tommy: get current time for initial game start in initialize_game function
+    let clock = Clock::get()?;
+
     game_state.authority = ctx.accounts.admin.key();
     game_state.prize_pool = INITIAL_PRIZE_POOL;
     game_state.path_length = INITIAL_PATH_LENGTH;
+    game_state.start = clock.unix_timestamp;
     game_state.game_events = Vec::new();
 
     msg!("Game initialized by admin");

--- a/programs/blockrunners/src/instructions/initialize_player.rs
+++ b/programs/blockrunners/src/instructions/initialize_player.rs
@@ -3,9 +3,10 @@ use anchor_lang::prelude::*;
 use crate::{
     constants::{
         DISCRIMINATOR_SIZE, 
-        PLAYER_STATE_SEED
+        PLAYER_STATE_SEED,
+        GAME_STATE_SEED
     }, 
-    state::PlayerState
+    state::{PlayerState, GameState}
 };
 
 #[derive(Accounts)]
@@ -22,6 +23,12 @@ pub struct InitializePlayer<'info> {
     )]
     pub player_state: Account<'info, PlayerState>,
 
+    #[account(
+        seeds = [GAME_STATE_SEED],
+        bump
+    )]
+    pub game_state: Account<'info, GameState>,
+
     pub system_program: Program<'info, System>,
 }
 
@@ -36,6 +43,9 @@ pub fn initialize_player(ctx: Context<InitializePlayer>) -> Result<()> {
     player_state.bump = ctx.bumps.player_state;
     player_state.player_events = Vec::new();
     player_state.in_game = false;
+
+    // tommy: save current game start time for this player in initialize_player
+    player_state.game_start = ctx.accounts.game_state.start;
 
     msg!("Player initialized");
     Ok(())

--- a/programs/blockrunners/src/state/game_state.rs
+++ b/programs/blockrunners/src/state/game_state.rs
@@ -14,6 +14,9 @@ pub struct GameState {
     /// The length of the path players need to navigate
     pub path_length: u8,
 
+    /// The Unix timestamp when the current game started
+    pub start: i64,
+
     #[max_len(MAX_FEED_EVENTS)]
     pub game_events: Vec<SocialFeedEvent>,
 }

--- a/programs/blockrunners/src/state/player_state.rs
+++ b/programs/blockrunners/src/state/player_state.rs
@@ -44,6 +44,9 @@ pub struct PlayerState {
     /// Store bump to save compute
     pub bump: u8,
 
+    /// tommy: The Unix timestamp of the game instance this player is part of i think
+    pub game_start: i64,
+
     #[max_len(MAX_FEED_EVENTS)]
     pub player_events: Vec<SocialFeedEvent>,
 

--- a/tests/make_move.ts
+++ b/tests/make_move.ts
@@ -311,10 +311,10 @@ describe("Make Move", () => {
     expect(gameStateAfter.prizePool.toNumber()).to.equal(0);
     expect(playerBalanceAfter).to.be.above(playerBalanceBefore);
 
-    // Verify player state was reset
-    expect(playerStateAfter.position).to.equal(0);
-    expect(playerStateAfter.cards.length).to.equal(0);
-    expect(playerStateAfter.playerEvents.length).to.equal(0);
+    // tommy: verify the game start time was updated to trigger resets
+    const gameStartBefore = gameStateBefore.start.toNumber();
+    const gameStartAfter = gameStateAfter.start.toNumber();
+    expect(gameStartAfter).to.be.above(gameStartBefore);
 
     // Verify win event was emitted
     expect(winEventCaptured).to.be.true;


### PR DESCRIPTION
…_move

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Players now receive the prize pool directly upon winning and their game state is reset.
  - Win events are emitted globally and for the player, including details such as public key, position, and prize amount.
  - Game start time is recorded and used to enforce game completion resets for all players.

- **Bug Fixes**
  - Ensured that prize lamports are transferred correctly and the prize pool resets to zero after a win.
  - Added explicit error handling for arithmetic overflow during prize distribution.

- **Tests**
  - Added a test to verify game completion, correct prize distribution, and state reset after a win.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->