### PR TITLE
feat: Add revenue distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,8 @@ This game has four main elements:
 
 - Players purchase ciphers, where 1 cipher = 1,000 lamports
 - Revenue distribution:
-  - 40% to prize pool
-  - 30% to creators
-  - 20% to oracles for randomness
-  - 10% to future game pools
+  - 88% to prize pool
+  - 12% to admin
 
 **Gameplay Loop**
 

--- a/app/src/context/BlockrunnersProvider.tsx
+++ b/app/src/context/BlockrunnersProvider.tsx
@@ -216,10 +216,16 @@ function BlockrunnersProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    if (!gameState || !gameState.authority) {
+      console.error("Purchase ciphers: Game state or admin authority not found");
+      return;
+    }
+
     program.methods
       .purchaseCiphers(new BN(amount))
       .accounts({
         player: wallet.publicKey,
+        adminWallet: gameState.authority,
       })
       .rpc()
       .then((tx) => {

--- a/app/src/idl/blockrunners.json
+++ b/app/src/idl/blockrunners.json
@@ -446,6 +446,10 @@
           }
         },
         {
+          "name": "admin_wallet",
+          "writable": true
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -1066,6 +1070,14 @@
       "name": "PLAYER_STATE_SEED",
       "type": "bytes",
       "value": "[112, 108, 97, 121, 101, 114, 95, 115, 116, 97, 116, 101]"
+    },
+    {
+      "name": "PRIZE_POOL_PERCENTAGE",
+      "docs": [
+        "Revenue distribution percentages"
+      ],
+      "type": "u64",
+      "value": "88"
     }
   ]
 }

--- a/app/src/idl/blockrunners.ts
+++ b/app/src/idl/blockrunners.ts
@@ -511,6 +511,10 @@ export type Blockrunners = {
           }
         },
         {
+          "name": "adminWallet",
+          "writable": true
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -1131,6 +1135,14 @@ export type Blockrunners = {
       "name": "playerStateSeed",
       "type": "bytes",
       "value": "[112, 108, 97, 121, 101, 114, 95, 115, 116, 97, 116, 101]"
+    },
+    {
+      "name": "prizePoolPercentage",
+      "docs": [
+        "Revenue distribution percentages"
+      ],
+      "type": "u8",
+      "value": "88"
     }
   ]
 };

--- a/programs/blockrunners/src/constants.rs
+++ b/programs/blockrunners/src/constants.rs
@@ -27,3 +27,7 @@ pub const PLAYER_STATE_SEED: &[u8] = b"player_state";
 /// Move success probability as a percentage (out of 100)
 #[constant]
 pub const MOVE_SUCCESS_PROBABILITY: u8 = 75;
+
+/// Revenue distribution percentages
+#[constant]
+pub const PRIZE_POOL_PERCENTAGE: u8 = 88;

--- a/programs/blockrunners/src/instructions/initialize_player.rs
+++ b/programs/blockrunners/src/instructions/initialize_player.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use crate::{
     constants::{DISCRIMINATOR_SIZE, GAME_STATE_SEED, PLAYER_STATE_SEED},
     instructions::update_last_login,
-    state::{Card, CardCounts, GameState, PlayerState},
+    state::{CardCounts, GameState, PlayerState},
 };
 
 #[derive(Accounts)]

--- a/programs/blockrunners/src/instructions/join_game.rs
+++ b/programs/blockrunners/src/instructions/join_game.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use crate::{
     constants::{GAME_STATE_SEED, PLAYER_STATE_SEED},
     errors::BlockrunnersError,
-    state::{Card, CardCounts, GameState, PlayerState, SocialFeedEventType},
+    state::{CardCounts, GameState, PlayerState, SocialFeedEventType},
     utils::save_and_emit_event,
 };
 

--- a/programs/blockrunners/src/utils/randomness_request.rs
+++ b/programs/blockrunners/src/utils/randomness_request.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use anchor_lang::prelude::*;
 use switchboard_on_demand::RandomnessAccountData;
 

--- a/programs/blockrunners/src/utils/randomness_reveal.rs
+++ b/programs/blockrunners/src/utils/randomness_reveal.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use anchor_lang::prelude::*;
 use switchboard_on_demand::RandomnessAccountData;
 

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -1,11 +1,16 @@
 import { getStringFromByteArray, getConstantOrThrow } from "./utils";
 import { BN } from "@coral-xyz/anchor";
+import { Keypair } from "@solana/web3.js";
+
+// Shared admin keypair for all tests
+export const ADMIN_KEYPAIR = Keypair.generate();
 
 // Number constants
 export const CIPHER_COST = new BN(getConstantOrThrow("cipherCost")).toNumber();
 export const INITIAL_PATH_LENGTH = Number(getConstantOrThrow("initialPathLength"));
 export const MAX_FEED_EVENTS = Number(getConstantOrThrow("maxFeedEvents"));
 export const INITIAL_PRIZE_POOL = new BN(getConstantOrThrow("initialPrizePool")).toNumber();
+export const PRIZE_POOL_PERCENTAGE = Number(getConstantOrThrow("prizePoolPercentage"));
 
 // String constants stored as byte arrays
 export const GAME_STATE_SEED = getStringFromByteArray(getConstantOrThrow("gameStateSeed"));

--- a/tests/initialize_game.ts
+++ b/tests/initialize_game.ts
@@ -4,7 +4,7 @@ import { Keypair, PublicKey } from "@solana/web3.js";
 import { expect } from "chai";
 import { Blockrunners } from "../target/types/blockrunners";
 import { airdropSol, getEventLogs, getMsgLogs, getTxDetails } from "./helpers/utils";
-import { GAME_STATE_SEED } from "./helpers/constants";
+import { GAME_STATE_SEED, ADMIN_KEYPAIR } from "./helpers/constants";
 
 describe("Initialize Game", () => {
   // Configure the client to use the local cluster
@@ -17,7 +17,7 @@ describe("Initialize Game", () => {
   const PATH_LENGTH = 20;
 
   // Keypairs
-  const adminKeypair = Keypair.generate();
+  const adminKeypair = ADMIN_KEYPAIR;
 
   // Game state PDA
   const [gameStatePda] = PublicKey.findProgramAddressSync(

--- a/tests/initialize_player.ts
+++ b/tests/initialize_player.ts
@@ -3,10 +3,7 @@ import { Program } from "@coral-xyz/anchor";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { expect } from "chai";
 import { Blockrunners } from "../target/types/blockrunners";
-import { 
-  GAME_STATE_SEED, 
-  PLAYER_STATE_SEED, 
-} from "./helpers/constants";
+import { GAME_STATE_SEED, PLAYER_STATE_SEED, ADMIN_KEYPAIR } from "./helpers/constants";
 import { airdropSol, getEventLogs, getMsgLogs, getTxDetails, sleep } from "./helpers/utils";
 
 describe("Initialize Player", () => {
@@ -16,8 +13,8 @@ describe("Initialize Player", () => {
   const program = anchor.workspace.blockrunners as Program<Blockrunners>;
   const provider = anchor.getProvider() as anchor.AnchorProvider;
 
-  // Keypairs
-  const adminKeypair = Keypair.generate();
+  // Generate test accounts
+  const adminKeypair = ADMIN_KEYPAIR;
   const playerKeypair = Keypair.generate();
 
   // Game state PDA

--- a/tests/join_game.ts
+++ b/tests/join_game.ts
@@ -3,7 +3,7 @@ import { Program } from "@coral-xyz/anchor";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { expect } from "chai";
 import { Blockrunners } from "../target/types/blockrunners";
-import { GAME_STATE_SEED, PLAYER_STATE_SEED } from "./helpers/constants";
+import { ADMIN_KEYPAIR, GAME_STATE_SEED, PLAYER_STATE_SEED } from "./helpers/constants";
 import { airdropSol, getEventLogs, getMsgLogs, getTxDetails } from "./helpers/utils";
 
 describe("Join game", () => {
@@ -13,8 +13,8 @@ describe("Join game", () => {
   const program = anchor.workspace.blockrunners as Program<Blockrunners>;
   const provider = anchor.getProvider() as anchor.AnchorProvider;
 
-  // Keypairs
-  const adminKeypair = Keypair.generate();
+  // Generate test accounts
+  const adminKeypair = ADMIN_KEYPAIR;
   const playerKeypair = Keypair.generate();
 
   // Game state PDA

--- a/tests/move.ts
+++ b/tests/move.ts
@@ -1,9 +1,9 @@
 import * as anchor from "@coral-xyz/anchor";
-import { Program } from "@coral-xyz/anchor";
+import { BN, Program } from "@coral-xyz/anchor";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { expect } from "chai";
 import { Blockrunners } from "../target/types/blockrunners";
-import { GAME_STATE_SEED, PLAYER_STATE_SEED } from "./helpers/constants";
+import { ADMIN_KEYPAIR, GAME_STATE_SEED, PLAYER_STATE_SEED } from "./helpers/constants";
 import {
   airdropSol,
   getEventLogs,
@@ -23,7 +23,7 @@ describe("Move Commit-Reveal", () => {
   const provider = anchor.getProvider() as anchor.AnchorProvider;
 
   // Keypairs
-  const adminKeypair = Keypair.generate();
+  const adminKeypair = ADMIN_KEYPAIR;
   const playerKeypair = Keypair.generate();
   const randomnessKeypair = Keypair.generate();
 
@@ -94,6 +94,7 @@ describe("Move Commit-Reveal", () => {
       .purchaseCiphers(new anchor.BN(ciphersToPurchase))
       .accounts({
         player: playerKeypair.publicKey,
+        adminWallet: adminKeypair.publicKey,
       })
       .signers([playerKeypair])
       .rpc();
@@ -111,6 +112,7 @@ describe("Move Commit-Reveal", () => {
       .purchaseCiphers(new anchor.BN(1))
       .accounts({
         player: playerKeypair.publicKey,
+        adminWallet: adminKeypair.publicKey,
       })
       .signers([playerKeypair])
       .rpc();
@@ -197,6 +199,7 @@ describe("Move Commit-Reveal", () => {
       .purchaseCiphers(new anchor.BN(3))
       .accounts({
         player: playerKeypair.publicKey,
+        adminWallet: adminKeypair.publicKey,
       })
       .signers([playerKeypair])
       .rpc();
@@ -254,6 +257,7 @@ describe("Move Commit-Reveal", () => {
       .purchaseCiphers(new anchor.BN(1))
       .accounts({
         player: playerKeypair.publicKey,
+        adminWallet: adminKeypair.publicKey,
       })
       .signers([playerKeypair])
       .rpc();
@@ -313,6 +317,7 @@ describe("Move Commit-Reveal", () => {
       .purchaseCiphers(new anchor.BN(1))
       .accounts({
         player: playerKeypair.publicKey,
+        adminWallet: adminKeypair.publicKey,
       })
       .signers([playerKeypair])
       .rpc();
@@ -430,6 +435,7 @@ describe("Move Commit-Reveal", () => {
       .purchaseCiphers(new anchor.BN(1))
       .accounts({
         player: playerKeypair.publicKey,
+        adminWallet: adminKeypair.publicKey,
       })
       .signers([playerKeypair])
       .rpc();
@@ -491,6 +497,7 @@ describe("Move Commit-Reveal", () => {
       .purchaseCiphers(new anchor.BN(movesNeeded))
       .accounts({
         player: playerKeypair.publicKey,
+        adminWallet: adminKeypair.publicKey,
       })
       .signers([playerKeypair])
       .rpc();


### PR DESCRIPTION
Closes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the game's revenue distribution: 88% of cipher purchase revenue now goes to the prize pool and 12% to the admin.
- **Bug Fixes**
  - Improved validation during cipher purchases to ensure proper admin authority is present before proceeding.
- **Documentation**
  - Revised the README to reflect the new, simplified revenue distribution model.
- **Tests**
  - Enhanced tests to verify correct revenue splitting between the prize pool and admin wallet during cipher purchases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->